### PR TITLE
Add RFC 0006 (Evals Extension) and revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # PromptPack Specification
 
-[![Spec Version](https://img.shields.io/badge/Spec-v1%20(Draft)-blue)](https://promptpack.org/docs/spec/overview)
+[![Spec Version](https://img.shields.io/badge/Spec-v1.1-blue)](https://promptpack.org/docs/spec/overview)
 [![Documentation](https://img.shields.io/badge/Documentation-promptpack.org-green)](https://promptpack.org)
 [![GitHub Pages](https://github.com/altairalabs/promptpack-spec/actions/workflows/deploy.yml/badge.svg)](https://github.com/altairalabs/promptpack-spec/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
-> **The open specification for packaging multi-prompt conversational AI systems into portable, reusable bundles.**
+> **Stop scattering prompts across files, repos, and providers. Package them once, run them anywhere.**
 
-PromptPack is a JSON-based format that packages everything needed to run sophisticated conversational AI—multiple specialized prompts, shared tools, reusable fragments, and configuration—into a single portable file.
+Production AI systems need more than a single prompt — they need specialized prompts, shared tools, reusable fragments, safety guardrails, and version control. PromptPack is a JSON-based spec that bundles all of that into one portable file that works across providers.
 
-## 🚀 Quick Start
+## Why PromptPack?
+
+**The problem:** As AI applications grow, prompt management becomes a mess — dozens of prompts scattered across codebases, duplicated tool definitions, no versioning, no testing, and tight coupling to a single provider.
+
+**The solution:** A single `.promptpack.json` file that contains:
+
+- **Multiple specialized prompts** that outperform one-size-fits-all approaches
+- **Shared tools and fragments** — define once, reuse everywhere
+- **Multimodal support** — text, images, audio, and structured content in prompt templates
+- **Built-in testing metadata** to track model performance across providers
+- **Portable format** that works with OpenAI, Anthropic, Google, and local models
+
+## Quick Start
 
 ```json
 {
@@ -21,15 +33,25 @@ PromptPack is a JSON-based format that packages everything needed to run sophist
     "version": "v1",
     "syntax": "{{variable}}"
   },
+  "tools": {
+    "lookup_order": {
+      "type": "function",
+      "description": "Look up a customer order by ID",
+      "parameters": {
+        "order_id": { "type": "string", "required": true }
+      }
+    }
+  },
+  "fragments": {
+    "brand_voice": "Always respond in a friendly, professional tone. Use the customer's first name."
+  },
   "prompts": {
     "support": {
-      "system_template": "You are a {{role}} for {{company}}. Help customers professionally.",
+      "system_template": "You are a {{role}} for {{company}}. {{fragments.brand_voice}}",
+      "tools": ["lookup_order"],
       "variables": [
-        {
-          "name": "role",
-          "type": "string",
-          "required": true
-        }
+        { "name": "role", "type": "string", "required": true },
+        { "name": "company", "type": "string", "required": true }
       ]
     }
   }
@@ -38,93 +60,66 @@ PromptPack is a JSON-based format that packages everything needed to run sophist
 
 **Learn more:** [Getting Started Guide](https://promptpack.org/docs/getting-started)
 
-## 📖 Documentation
+## Key Features
 
-- **📋 [Specification](https://promptpack.org/docs/spec/overview)** - Complete PromptPack spec
-- **🔧 [Examples](https://promptpack.org/docs/spec/examples)** - Real-world usage examples  
-- **📚 [Schema Reference](https://promptpack.org/docs/spec/schema-reference)** - Field-by-field documentation
-- **🏗️ [File Format](https://promptpack.org/docs/spec/file-format)** - YAML structure guide
+- **Multi-Prompt Architecture** — Specialized prompts for different scenarios instead of one-size-fits-all
+- **Complete Packaging** — Prompts, tools, fragments, and config in a single JSON file
+- **Multimodal Content** — Text, images, audio, and structured content in prompt templates
+- **Portable & Provider-Agnostic** — Works across OpenAI, Anthropic, Google, and local models
+- **Built-in Testing** — Testing metadata and quality assurance built into the spec
+- **Tool Integration** — Define external tools once, reference them across all prompts
+- **Template System** — Variable templating with reusable fragments for consistency
+
+## Documentation
+
+- [Specification](https://promptpack.org/docs/spec/overview) — Complete PromptPack spec
+- [Examples](https://promptpack.org/docs/spec/examples) — Real-world usage examples
+- [Schema Reference](https://promptpack.org/docs/spec/schema-reference) — Field-by-field documentation
+- [File Format](https://promptpack.org/docs/spec/file-format) — YAML structure guide
 
 ### JSON Schema
 
 - **Latest:** [`https://promptpack.org/schema/latest/promptpack.schema.json`](https://promptpack.org/schema/latest/promptpack.schema.json)
 - **Versioned:** `https://promptpack.org/schema/v1.1/promptpack.schema.json`
 
-## 🌟 Key Features
+## Ecosystem
 
-- **🎯 Multi-Prompt Architecture** - Specialized prompts for different scenarios instead of one-size-fits-all
-- **📦 Complete Packaging** - Everything needed (prompts, tools, fragments) in a single JSON file
-- **🔄 Reusable & Portable** - Works across different AI providers and deployment environments
-- **🧪 Built-in Testing** - Testing metadata and quality assurance built into the specification
-- **🛠️ Tool Integration** - Define external tools once, use across all prompts in the pack
-- **🎨 Template System** - Consistent variable templating with reusable fragments
+| Component | Status | Links |
+|-----------|--------|-------|
+| **Core Specification** | v1.1 Stable | [Spec](https://promptpack.org/docs/spec/overview) |
+| **PromptKit** | Stable | [CLI, validation, SDK](https://promptpack.org/docs/ecosystem/promptkit-runtime) |
+| **PromptArena** | Stable | [Multi-provider testing, CI/CD](https://promptpack.org/docs/ecosystem/arena-testing) |
+| **LangChain.js** | Available | [`@promptpack/langchain`](https://github.com/AltairaLabs/promptpack-langchainjs) |
+| **LangChain Python** | Available | [`promptpack-python`](https://github.com/AltairaLabs/promptpack-python) |
+| **JSON Schema** | Available | [Auto-versioned schema](https://promptpack.org/schema/latest/promptpack.schema.json) |
+| **Documentation** | Live | [promptpack.org](https://promptpack.org) |
 
-## 🏛️ Governance and RFC Process
+## Governance
 
-PromptPack follows an open governance model inspired by CNCF projects:
+PromptPack follows an open governance model. See our [Governance Model](./GOVERNANCE.md), [RFC Process](https://promptpack.org/docs/processes/rfc-process), and [RFC Index](https://promptpack.org/docs/processes/rfc-index).
 
-- **📋 [Governance Model](./GOVERNANCE.md)** - How decisions are made
-- **🔄 [RFC Process](https://promptpack.org/docs/processes/rfc-process)** - Proposing specification changes
-- **📊 [RFC Index](https://promptpack.org/docs/processes/rfc-index)** - Active and completed RFCs
+## Contributing
 
-### Maintainers
+We welcome contributions! Here's how to get involved:
 
-- **Core Maintainers:** Oversee specification development and governance
-- **Spec Editors:** Review and approve changes to the specification
-- **Contributors:** Community members contributing to the project
+1. Read the [Contributing Guide](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md)
+2. Join [GitHub Discussions](https://github.com/altairalabs/promptpack-spec/discussions)
+3. Report issues using our [issue templates](.github/ISSUE_TEMPLATE/)
+4. Propose specification changes via the [RFC process](https://promptpack.org/docs/processes/rfc-process)
 
-## 🤝 Contributing
+Look for issues labeled `good first issue` to get started.
 
-We welcome contributions from the community! Here's how to get involved:
+## Community
 
-1. **📖 Read:** [Contributing Guide](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md)
-2. **💬 Discuss:** Join [GitHub Discussions](https://github.com/altairalabs/promptpack-spec/discussions)
-3. **🐛 Report Issues:** Use our [issue templates](.github/ISSUE_TEMPLATE/)
-4. **🔄 Submit RFCs:** Propose specification changes via RFC process
+- **Website:** [promptpack.org](https://promptpack.org)
+- **Discussions:** [GitHub Discussions](https://github.com/altairalabs/promptpack-spec/discussions)
+- **Issues:** [Issue Tracker](https://github.com/altairalabs/promptpack-spec/issues)
+- **Contact:** [community@altairalabs.com](mailto:community@altairalabs.com)
 
-**New contributors welcome!** Look for issues labeled `good first issue`.
+## License
 
-## 🚀 Roadmap and Governance
-
-Track our progress and upcoming features:
-
-- **📊 [Project Roadmap](https://github.com/orgs/altairalabs/projects/1)** - Development roadmap
-- **🎯 [Milestones](https://github.com/altairalabs/promptpack-spec/milestones)** - Release planning
-- **📈 [Community Standards](https://github.com/altairalabs/promptpack-spec/community)** - Health metrics
-
-## 💡 Why PromptPacks?
-
-**The Problem**: Building production conversational AI requires multiple specialized prompts, external tools, shared resources, safety guardrails, and version management. Without standardization, AI applications become fragmented and hard to maintain.
-
-**The Solution**: PromptPacks package everything into a single JSON file with:
-
-- **Multiple specialized prompts** (support, sales, technical) that outperform generic prompts
-- **Shared tools and fragments** to eliminate duplication and ensure consistency  
-- **Built-in testing metadata** to track model performance and success rates
-- **Portable format** that works across providers (OpenAI, Anthropic, local models)
-
-## 🏗️ Implementation Status
-
-| Component | Status | Description |
-|-----------|--------|-------------|
-| **Core Specification** | ✅ v1 Draft | Complete JSON-based specification with examples |
-| **JSON Schema** | ✅ Available | Validation schema with automatic versioning |
-| **Documentation Site** | ✅ Live | Comprehensive docs at promptpack.org |
-| **LangChain.js Integration** | ✅ Available | [`@promptpack/langchain`](https://github.com/AltairaLabs/promptpack-langchainjs) npm package |
-| **Reference Runtime** | 🚧 In Development | [PromptKit](https://promptpack.org/docs/ecosystem/promptkit-runtime) |
-| **Testing Framework** | 🚧 In Development | [Arena Testing](https://promptpack.org/docs/ecosystem/arena-testing) |
-
-## 📊 Community
-
-- **🌐 Website:** [promptpack.org](https://promptpack.org)
-- **💬 Discussions:** [GitHub Discussions](https://github.com/altairalabs/promptpack-spec/discussions)
-- **🐛 Issues:** [Issue Tracker](https://github.com/altairalabs/promptpack-spec/issues)
-- **📧 Contact:** [community@altairalabs.com](mailto:community@altairalabs.com)
-
-## 📄 License
-
-This project is licensed under the [MIT License](./LICENSE) - see the LICENSE file for details.
+This project is licensed under the [MIT License](./LICENSE).
 
 ---
 
-**Built by [AltairaLabs](https://altairalabs.com) with ❤️ for the conversational AI community.**
+**Built by [AltairaLabs](https://altairalabs.com) for the conversational AI community.**


### PR DESCRIPTION
## Summary
- **RFC 0006: Evals Extension** — Adds a new RFC proposing an evals extension to the PromptPack spec
- **Documentation cleanup** — Fixes consistency issues across JSON schemas, examples, and ecosystem docs
- **README revamp** — Updates README to reflect v1.1 status, rewrites hero/value-prop sections, enriches Quick Start example, replaces Implementation Status with full Ecosystem table (PromptKit, Arena, LangChain Python all stable/available), and trims stale roadmap/governance sections

## Test plan
- [ ] Verify RFC 0006 renders correctly in the docs site
- [ ] Confirm all README links resolve correctly
- [ ] Review documentation changes for accuracy and consistency