### PR TITLE
docs(rfc-0009): mark Agent Loop Extension as Implemented

### DIFF
--- a/promptpack-docs/docs/processes/rfc-index.md
+++ b/promptpack-docs/docs/processes/rfc-index.md
@@ -32,6 +32,7 @@ The RFC (Request for Comments) process is how the PromptPack community proposes,
 | [RFC-0006](/docs/rfcs/evals-extension) | 🚀 Implemented | Evals Extension |
 | [RFC-0007](/docs/rfcs/agents-extension) | 🚀 Implemented | Agents Extension |
 | [RFC-0008](/docs/rfcs/skills-extension) | 🚀 Implemented | Skills Extension |
+| [RFC-0009](/docs/rfcs/agent-loops) | 🚀 Implemented | Agent Loop Extension |
 <!-- RFC_TABLE_END -->
 
 ## Upcoming Considerations

--- a/rfcs/0009-agent-loops.md
+++ b/rfcs/0009-agent-loops.md
@@ -1,9 +1,9 @@
 # RFC 0009: Agent Loop Extension
 
-- **Status:** Draft
+- **Status:** Implemented
 - **Author(s):** AltairaLabs Team
 - **Created:** 2026-03-26
-- **Updated:** 2026-03-26
+- **Updated:** 2026-04-18
 - **Related Issues:** N/A
 
 ## Summary


### PR DESCRIPTION
## Summary

RFC 0009 status changes from **Draft** → **Implemented** in lockstep with [AltairaLabs/PromptKit#987](https://github.com/AltairaLabs/PromptKit/pull/987) (the last compliance gap — v2 reachability warning in the workflow validator, now merged).

PromptKit runtime satisfies **Level 2** conformance:

- `terminal`, `max_visits`, `on_max_visits` loop guards
- `artifacts` slots with `replace`/`append` modes
- `{{artifacts.<name>}}` template variable injection (workflow-scoped namespace)
- `engine.budget` enforcement (`max_total_visits`, `max_tool_calls`, `max_wall_time_sec`) with structured `BudgetExhaustedError`
- All validators from the RFC: `on_max_visits` target existence, terminal + `on_event` contradiction warning, redirect-chain warning, and v2 non-terminal-without-exit reachability warning

## Changes

- `rfcs/0009-agent-loops.md` — status Draft → Implemented, updated date to 2026-04-18
- `promptpack-docs/docs/processes/rfc-index.md` — regenerated via `sync-rfcs`; RFC 0009 now appears as 🚀 Implemented

## Test plan

- [x] `sync-rfcs` regenerates `promptpack-docs/docs/rfcs/0009-agent-loops.md` with frontmatter (gitignored — produced on build)
- [ ] Docusaurus build (`prebuild` runs `sync-rfcs`) picks up the new status on next deploy