### PR TITLE
docs: braid PromptKit into README as the reference toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Production AI systems need more than a single prompt — they need specialized prompts, shared tools, reusable fragments, safety guardrails, and version control. PromptPack is a JSON-based spec that bundles all of that into one portable file that works across providers.
 
+**Want to use it, not just read about it?** [**PromptKit**](https://github.com/AltairaLabs/PromptKit) is the open-source reference toolkit — install it with `npm install -g @altairalabs/promptarena @altairalabs/packc` to test, validate, and run packs in production.
+
 ## Why PromptPack?
 
 **The problem:** As AI applications grow, prompt management becomes a mess — dozens of prompts scattered across codebases, duplicated tool definitions, no versioning, no testing, and tight coupling to a single provider.
@@ -80,6 +82,20 @@ Production AI systems need more than a single prompt — they need specialized p
 ```
 
 **Learn more:** [Getting Started Guide](https://promptpack.org/docs/getting-started)
+
+### Run a pack
+
+Once you've authored a pack, install [PromptKit](https://github.com/AltairaLabs/PromptKit) and try it:
+
+```bash
+npm install -g @altairalabs/promptarena @altairalabs/packc
+
+promptarena init my-project --template iot-maintenance-demo
+cd my-project
+promptarena run --scenario scenarios/hardware-faults.scenario.yaml
+```
+
+PromptKit is the reference toolkit — multi-provider testing, red-team scenarios, eval reporting, and SDK deployment.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

Mirrors the matching update on the PromptKit side ([AltairaLabs/PromptKit#1071](https://github.com/AltairaLabs/PromptKit/pull/1071)) so the funnel braids in both directions.

- **First-paragraph callout** points spec-curious visitors at PromptKit as the open-source reference toolkit, with the npm one-liner inline
- **"Run a pack" sub-section** added under the JSON Quick Start so readers can move from spec example → running something locally without scrolling to the Ecosystem table 200 lines down

## What's unchanged

- Tagline ("Stop scattering prompts...")
- Why PromptPack? section
- Key Features
- Evals / Workflows / Skills feature deep-dives
- Ecosystem table (PromptKit / PromptArena / adapters listed)
- Governance / Contributing / License sections

## Test plan

- [ ] Visual review of rendered README on the PR page
- [ ] PromptKit link resolves
- [ ] npm install command renders as expected (single line, copyable)