### PR TITLE
feat: release v1.4.0 — agent loops in schema + drift safeguards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,19 @@ Brief description of changes made in this PR.
 - [ ] RFC implementation
 - [ ] Spec change or clarification
 
+## RFC implementation checklist
+
+Complete this section if this PR marks an RFC as **Implemented** or **Accepted**, OR if it changes the schema's `version` field. Skip otherwise.
+
+- [ ] All schema fields described by the RFC are present in `schema/promptpack.schema.json`
+- [ ] `schema/promptpack.schema.json` `version` is bumped to match the release that includes this RFC
+- [ ] README badge `Spec-vX.Y.Z-blue` matches the schema version
+- [ ] README has a `## <Feature> *(vX.Y)*` section describing the new fields with an example
+- [ ] Versioned schema URL in README (`https://promptpack.org/schema/vX.Y.Z/...`) matches the new version
+- [ ] RFC document's `Status:` field reflects reality (`Implemented` only when schema **and** runtime support is in)
+
+> **Why this exists:** RFC-0009 was marked Implemented in PR #38 because the runtime supported it, but the schema fields weren't added. The badge and per-feature markers drifted from the schema state. This checklist closes that gap.
+
 ## Related Issues
 
 Closes #(issue number)

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,23 @@
+name: Version consistency
+
+on:
+  pull_request:
+    paths:
+      - "schema/promptpack.schema.json"
+      - "README.md"
+      - "scripts/check-version-consistency.mjs"
+      - ".github/workflows/version-check.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: Schema / README version drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run consistency check
+        run: node scripts/check-version-consistency.mjs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PromptPack Specification
 
-[![Spec Version](https://img.shields.io/badge/Spec-v1.3.1-blue)](https://promptpack.org/docs/spec/overview)
+[![Spec Version](https://img.shields.io/badge/Spec-v1.4.0-blue)](https://promptpack.org/docs/spec/overview)
 [![Documentation](https://img.shields.io/badge/Documentation-promptpack.org-green)](https://promptpack.org)
 [![GitHub Pages](https://github.com/altairalabs/promptpack-spec/actions/workflows/deploy.yml/badge.svg)](https://github.com/altairalabs/promptpack-spec/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
@@ -87,6 +87,7 @@ Production AI systems need more than a single prompt — they need specialized p
 - **Complete Packaging** — Prompts, tools, fragments, evals, and config in a single JSON file
 - **Evals & Metrics** — Declare automated quality checks (deterministic or LLM judge) with Prometheus metric export
 - **Workflows** — State-machine orchestration with event-driven transitions between prompts
+- **Agent Loops** — Iterative, self-correcting execution with terminal states, per-state visit guards, artifact trails, and engine budgets
 - **Agents** — A2A-compatible agent definitions for multi-agent discovery and orchestration
 - **Skills** — Progressive-disclosure knowledge loading with workflow state scoping
 - **Multimodal Content** — Text, images, audio, and structured content in prompt templates
@@ -194,6 +195,51 @@ Workflow states can scope which skills are available per context:
 
 See [RFC-0008: Skills Extension](https://promptpack.org/docs/rfcs/skills-extension) for the full design.
 
+## Agent Loops *(v1.4)*
+
+PromptPack v1.4 extends the workflow state machine with the guardrails needed for safe, productive agent loops: terminal states, per-state visit limits, lightweight artifact slots that flow across visits, and engine-level execution budgets.
+
+```json
+"workflow": {
+  "version": 1,
+  "entry": "plan",
+  "states": {
+    "plan":      { "prompt_task": "plan",   "on_event": { "PlanReady": "implement" } },
+    "implement": {
+      "prompt_task": "implement",
+      "max_visits": 5,
+      "on_max_visits": "review",
+      "artifacts": {
+        "commit_sha":  { "type": "text/plain", "description": "Latest generated commit" },
+        "test_report": { "type": "application/json", "description": "Test runner summary" }
+      },
+      "on_event": { "CodeReady": "test" }
+    },
+    "test":      {
+      "prompt_task": "run_tests",
+      "on_event":    { "TestsFailed": "implement", "TestsPassed": "done" }
+    },
+    "review":    { "prompt_task": "review", "terminal": true },
+    "done":      { "prompt_task": "summarize", "terminal": true }
+  },
+  "engine": {
+    "budget": { "max_total_visits": 50, "max_tool_calls": 200, "max_wall_time_sec": 600 }
+  }
+}
+```
+
+**Key concepts:**
+
+| Feature | Description |
+|---------|-------------|
+| **Terminal states** | `terminal: true` marks workflow exit points explicitly |
+| **Loop guards** | Per-state `max_visits` + optional `on_max_visits` redirect — bounds individual loops without killing the whole workflow |
+| **Artifacts** | Named slots (`replace`/`append`) carry pointers, summaries, and structured results across visits; available to prompts as `{{artifacts.<name>}}` |
+| **Budgets** | `engine.budget` provides a global safety net (total visits, tool calls, wall time) independent of per-state limits |
+| **Time-travel debugging** | Artifacts are captured at every transition — runtimes get a complete, replayable execution trace for free |
+
+See [RFC-0009: Agent Loop Extension](https://promptpack.org/docs/rfcs/agent-loops) for the full design.
+
 ## Documentation
 
 - [Specification](https://promptpack.org/docs/spec/overview) — Complete PromptPack spec
@@ -204,7 +250,7 @@ See [RFC-0008: Skills Extension](https://promptpack.org/docs/rfcs/skills-extensi
 ### JSON Schema
 
 - **Latest:** [`https://promptpack.org/schema/latest/promptpack.schema.json`](https://promptpack.org/schema/latest/promptpack.schema.json)
-- **Versioned:** `https://promptpack.org/schema/v1.3.1/promptpack.schema.json`
+- **Versioned:** `https://promptpack.org/schema/v1.4.0/promptpack.schema.json`
 
 ## Ecosystem
 

--- a/schema/promptpack.schema.json
+++ b/schema/promptpack.schema.json
@@ -2,8 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://promptpack.org/schema/latest/promptpack.schema.json",
   "title": "PromptPack Specification",
-  "description": "Schema for packaging, testing, and running multi-prompt conversational systems with multimodal, workflow, agent, and skills support",
-  "version": "1.3.1",
+  "description": "Schema for packaging, testing, and running multi-prompt conversational systems with multimodal, workflow, agent, agent-loop, and skills support",
+  "version": "1.4.0",
   "type": "object",
   "required": ["id", "name", "version", "template_engine", "prompts"],
   "additionalProperties": false,
@@ -1288,7 +1288,13 @@
         },
         "engine": {
           "type": "object",
-          "description": "Optional runtime engine hints for workflow execution (e.g., timeout, concurrency settings).",
+          "description": "Optional runtime engine configuration for workflow execution. Hosts standardized fields like 'budget' for resource limits, alongside runtime-specific hints (timeout, concurrency, etc.).",
+          "properties": {
+            "budget": {
+              "$ref": "#/$defs/WorkflowBudget",
+              "description": "Resource budget for workflow execution. Provides safety limits to prevent unbounded loops."
+            }
+          },
           "additionalProperties": true
         }
       }
@@ -1296,7 +1302,7 @@
 
     "WorkflowState": {
       "type": "object",
-      "description": "A single state in the workflow state machine. References a prompt task and declares event-driven transitions to other states.",
+      "description": "A single state in the workflow state machine. References a prompt task and declares event-driven transitions to other states. May be marked as terminal to indicate workflow completion, or guarded with max_visits to bound loop iterations.",
       "required": ["prompt_task"],
       "additionalProperties": false,
       "properties": {
@@ -1331,6 +1337,87 @@
           "type": "string",
           "description": "Skill filter for this workflow state. A path to a skill directory/file that scopes which skills are available in this state, or the literal 'none' to disable skills.",
           "examples": ["./skills/billing", "none"]
+        },
+        "terminal": {
+          "type": "boolean",
+          "description": "If true, this state is a terminal state. The workflow completes after this state's prompt executes. Terminal states should not declare on_event transitions.",
+          "default": false,
+          "examples": [true]
+        },
+        "max_visits": {
+          "type": "integer",
+          "description": "Maximum number of times this state can be entered during a single workflow execution. When the limit is reached, the workflow transitions to the state named in on_max_visits. If on_max_visits is not set, the workflow terminates.",
+          "minimum": 1,
+          "examples": [5, 10, 20]
+        },
+        "on_max_visits": {
+          "type": "string",
+          "description": "Target state to transition to when max_visits is reached. Must reference a key in the states object. If omitted and max_visits is reached, the workflow terminates with a budget-exhausted status.",
+          "examples": ["review", "summarize", "error_handler"]
+        },
+        "artifacts": {
+          "type": "object",
+          "description": "Named artifact slots for lightweight, structured metadata that flows across state visits. Artifacts should be pointers (commit SHAs, URIs), compact representations (schemas, summaries, diffs), or small structured results — not bulk data. Artifact values are available to the prompt as template variables under the 'artifacts' namespace (e.g., {{artifacts.commit_sha}}).",
+          "additionalProperties": {
+            "$ref": "#/$defs/ArtifactDef"
+          },
+          "examples": [
+            {
+              "commit_sha": { "type": "text/plain", "description": "Git commit of the latest generated code" },
+              "test_report": { "type": "application/json", "description": "Structured test runner summary" }
+            }
+          ]
+        }
+      }
+    },
+
+    "ArtifactDef": {
+      "type": "object",
+      "description": "Declares a named artifact slot for carrying lightweight, structured metadata across workflow state visits. Artifacts are typically pointers (commit SHAs, file paths, URIs), compact representations (schemas, summaries, diffs), or small structured results — not bulk data. Values are captured at each state transition, forming an observable trace that enables time-travel debugging and workflow audit. They persist across loop iterations and are accessible to prompts as template variables.",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "MIME type indicating the artifact's content type. Used by runtimes to determine serialization and presentation.",
+          "examples": ["text/plain", "application/json", "text/markdown", "text/x-python"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this artifact contains and how it's used."
+        },
+        "mode": {
+          "type": "string",
+          "description": "How the artifact is updated across visits. 'replace' overwrites the previous value on each visit. 'append' accumulates content across visits (e.g., a log). Defaults to 'replace'.",
+          "enum": ["replace", "append"],
+          "default": "replace",
+          "examples": ["replace", "append"]
+        }
+      }
+    },
+
+    "WorkflowBudget": {
+      "type": "object",
+      "description": "Resource budget for workflow execution. Provides a safety net to prevent unbounded loops. When any budget limit is reached, the workflow terminates with a budget-exhausted status. All fields are optional — omitting a field means no limit for that resource.",
+      "additionalProperties": false,
+      "properties": {
+        "max_total_visits": {
+          "type": "integer",
+          "description": "Maximum total state visits across all states in the workflow. This is a global safety net independent of per-state max_visits.",
+          "minimum": 1,
+          "examples": [50, 100, 200]
+        },
+        "max_tool_calls": {
+          "type": "integer",
+          "description": "Maximum total tool calls across all states in the workflow.",
+          "minimum": 1,
+          "examples": [100, 500]
+        },
+        "max_wall_time_sec": {
+          "type": "integer",
+          "description": "Maximum wall-clock time in seconds for the entire workflow execution.",
+          "minimum": 1,
+          "examples": [300, 600, 3600]
         }
       }
     },

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * Asserts that the spec version is consistent across:
+ *   - schema/promptpack.schema.json   (the source of truth)
+ *   - README.md badge                 ("Spec-vX.Y.Z-blue")
+ *   - README.md versioned schema URL  ("schema/vX.Y.Z/promptpack.schema.json")
+ *
+ * Exists because RFC-0009 was marked "Implemented" while the schema fields
+ * weren't added — drift that no automated check caught. This script is the
+ * automated check.
+ *
+ * Usage:
+ *   node scripts/check-version-consistency.mjs
+ *
+ * Exits 0 on success, 1 on any drift.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+const schema = JSON.parse(
+  readFileSync(resolve(repoRoot, "schema/promptpack.schema.json"), "utf-8")
+);
+const readme = readFileSync(resolve(repoRoot, "README.md"), "utf-8");
+
+const schemaVersion = schema.version;
+
+const badgeMatch = readme.match(/Spec-v([0-9]+\.[0-9]+\.[0-9]+)-blue/);
+const urlMatch = readme.match(
+  /schema\/v([0-9]+\.[0-9]+\.[0-9]+)\/promptpack\.schema\.json/
+);
+
+const errors = [];
+
+if (!schemaVersion) {
+  errors.push("schema/promptpack.schema.json is missing a top-level `version` field.");
+}
+
+if (!badgeMatch) {
+  errors.push(
+    "README.md is missing the `Spec-vX.Y.Z-blue` shields.io badge — can't verify badge version."
+  );
+} else if (badgeMatch[1] !== schemaVersion) {
+  errors.push(
+    `README badge version (v${badgeMatch[1]}) does not match schema version (v${schemaVersion}). ` +
+      `Update the [![Spec Version](...)] line in README.md.`
+  );
+}
+
+if (!urlMatch) {
+  errors.push(
+    "README.md is missing the versioned schema URL (`schema/vX.Y.Z/promptpack.schema.json`) — can't verify."
+  );
+} else if (urlMatch[1] !== schemaVersion) {
+  errors.push(
+    `README versioned schema URL (v${urlMatch[1]}) does not match schema version (v${schemaVersion}). ` +
+      `Update the "Versioned:" line in README.md's JSON Schema section.`
+  );
+}
+
+if (errors.length > 0) {
+  console.error("[check-version-consistency] FAIL\n");
+  for (const e of errors) console.error("  - " + e);
+  console.error(
+    "\nFix the drift above. Schema is the source of truth; README must follow."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[check-version-consistency] ok — schema, badge, and versioned URL all at v${schemaVersion}.`
+);


### PR DESCRIPTION
## Summary

Closes the gap between **RFC-0009: Agent Loop Extension** being marked *Implemented* (in #38, runtime-supported) and the JSON schema not actually declaring the corresponding fields. Pack authors using \`terminal\`, \`max_visits\`, \`artifacts\`, or \`engine.budget\` would have failed schema validation despite the runtime honoring those fields.

This PR ships v1.4.0 and adds two safeguards so this drift can't happen again.

## Schema (v1.3.1 → v1.4.0)

- \`WorkflowState\` gains \`terminal\`, \`max_visits\`, \`on_max_visits\`, \`artifacts\`
- New \`\$defs.ArtifactDef\` (replace/append modes, MIME types)
- New \`\$defs.WorkflowBudget\` (max_total_visits, max_tool_calls, max_wall_time_sec)
- \`WorkflowConfig.engine.budget\` is now formally typed (was \`additionalProperties: true\` only)
- Top-level \`description\` updated to mention agent-loop support
- All \`\$ref\`s validated; schema parses cleanly (45KB)

## README

- Badge updated to \`Spec-v1.4.0-blue\`
- New **\"Agent Loops *(v1.4)*\"** section with a complete codegen-loop example pack
- \"Agent Loops\" added to Key Features list
- Versioned schema URL bumped to \`v1.4.0\`

## Drift safeguards (the 'can't happen again' part)

1. **\`scripts/check-version-consistency.mjs\`** — asserts \`schema.version\`, README badge (\`Spec-vX.Y.Z-blue\`), and versioned schema URL all match. Exits non-zero on drift with a clear error message. Currently passes (\`ok — schema, badge, and versioned URL all at v1.4.0\`).

2. **\`.github/workflows/version-check.yml\`** — runs the script on every PR that touches schema or README, plus on push to main.

3. **PR template \"RFC implementation checklist\"** — six explicit items reviewers tick when marking an RFC \"Implemented\" or changing schema version. Includes a brief explainer of why this checklist exists (so reviewers know the history without us needing to point at this PR).

## Test plan

- [x] Local script run passes
- [ ] Visual review of rendered README (badge color, section position, code-block syntax)
- [ ] CI \`Version consistency\` check passes on this PR
- [ ] Confirm PR template renders correctly when opening a follow-up PR
- [ ] Confirm \`generate-schema-docs.yml\` regenerates docs site cleanly with new fields after merge

## Deliberately out of scope

- RFC-0010 (Workflow Composition) is still Draft — no schema changes for \`composition\` mode in this PR
- Auto-generated schema docs in \`promptpack-docs/\` will regenerate via existing CI on merge
- The runtime-side conformance label (Level 2 etc.) is owned by PromptKit, not this repo