### PR TITLE
docs: reconcile docs with schema (cleanup audit)

### DIFF
--- a/promptpack-docs/docs/guides/add-evals.md
+++ b/promptpack-docs/docs/guides/add-evals.md
@@ -60,12 +60,14 @@ Each eval requires:
 
 ## Step 3: Choose Triggers
 
-The `trigger` field controls when the eval runs:
+The `trigger` field controls when the eval runs. The schema is open — runtimes can register their own trigger types — but these are the conventional values:
 
 | Trigger | Behavior | Use When |
 |---------|----------|----------|
 | `every_turn` | Runs on every LLM response | Critical quality checks (accuracy, structure) |
 | `on_session_complete` | Runs once per session | Session-level assessments (overall tone, completeness) |
+| `on_conversation_complete` | Runs once per conversation | Multi-session journeys; cross-session quality |
+| `on_workflow_step` | Runs at each workflow state transition | Per-state quality checks in workflow-driven packs |
 | `sample_turns` | Samples a percentage of turns | Expensive evals (LLM judge) on high-traffic prompts |
 | `sample_sessions` | Samples a percentage of sessions | Holistic quality audits |
 
@@ -308,10 +310,10 @@ A full pack with pack-level and prompt-level evals:
 ## Validation Checklist
 
 - [ ] Each eval has a unique `id` within its scope (pack-level or within a prompt)
-- [ ] `trigger` is one of: `every_turn`, `on_session_complete`, `sample_turns`, `sample_sessions`
+- [ ] `trigger` is set (schema is open; common values listed in Step 3)
 - [ ] `sample_percentage` is set when using `sample_turns` or `sample_sessions` triggers
 - [ ] `metric.name` follows Prometheus conventions (snake_case, namespace prefix)
-- [ ] `metric.type` is one of: `gauge`, `counter`, `histogram`, `boolean`
+- [ ] `metric.type` is one of: `gauge`, `counter`, `histogram`, `boolean` *(this one **is** an enum)*
 - [ ] `metric.range.min` &le; `metric.range.max` when range is specified
 - [ ] Pack validates against the v1.2+ JSON schema
 

--- a/promptpack-docs/docs/guides/add-skills.md
+++ b/promptpack-docs/docs/guides/add-skills.md
@@ -9,7 +9,7 @@ Add progressive-disclosure knowledge loading to an existing PromptPack so that a
 
 ## Prerequisites
 
-- A PromptPack (v1.3.1 schema)
+- A PromptPack (v1.3.1+ schema)
 - Understanding of [Pack Structure](/docs/spec/structure)
 - Knowledge you want to make available to agents beyond what's in system templates
 
@@ -180,7 +180,7 @@ If your pack uses a workflow, you can filter which skills are available in each 
 
 After adding skills, verify:
 
-- [ ] Pack validates against the v1.3.1 schema
+- [ ] Pack validates against the v1.3.1+ schema
 - [ ] All file paths point to existing directories/files (if using path-based skills)
 - [ ] Inline skills have all three required fields: `name`, `description`, `instructions`
 - [ ] `SkillPathSource` objects have a `path` field

--- a/promptpack-docs/docs/guides/setup-agents.md
+++ b/promptpack-docs/docs/guides/setup-agents.md
@@ -9,7 +9,7 @@ Make your PromptPack prompts discoverable via the A2A (Agent-to-Agent) protocol 
 
 ## Prerequisites
 
-- A PromptPack with at least 1 prompt (v1.3 schema)
+- A PromptPack with at least 1 prompt (v1.3+ schema)
 - Understanding of [Pack Structure](/docs/spec/structure)
 
 ## Step 1: Choose Which Prompts Become Agents
@@ -42,7 +42,7 @@ Add the `agents` top-level field with `entry` and `members`:
 Key rules:
 - `entry` must reference a key in `members`
 - Each key in `members` must match a key in `prompts`
-- `description` is required — it becomes the agent's A2A Agent Card description
+- `description` is technically optional in the schema but **strongly recommended** — it becomes the agent's A2A Agent Card description and is what registries and routers use for discovery
 
 ## Step 3: Configure Tags and MIME Types
 
@@ -227,14 +227,14 @@ A full pack with three standalone agents:
 
 - [ ] `agents.entry` references a valid key in `members`
 - [ ] Every key in `members` matches a key in `prompts`
-- [ ] Every member has a `description`
+- [ ] Every member has a `description` *(optional in schema, but required in practice for A2A discovery)*
 - [ ] If using workflow + agents, `workflow.entry` and `agents.entry` can differ (they serve different purposes)
 - [ ] MIME types in `input_modes`/`output_modes` are valid
-- [ ] Pack validates against the v1.3 JSON schema
+- [ ] Pack validates against the v1.3+ JSON schema
 
 :::warning Common Mistakes
 - **Agent key doesn't match prompt key**: `members.billing_agent` won't work if the prompt key is `billing`. The keys must match exactly.
-- **Missing description**: Every agent member must have a `description` — this becomes the A2A Agent Card's description and is essential for discovery.
+- **Missing description**: The schema technically allows agent members without a `description`, but you almost always want one — it becomes the A2A Agent Card's description and is what registries and routers use for discovery.
 - **Confusing workflow entry with agent entry**: `workflow.entry` is the first *state* in the state machine. `agents.entry` is the default agent for *incoming external requests*. They can reference different prompts.
 :::
 

--- a/promptpack-docs/docs/spec/schema-guide.md
+++ b/promptpack-docs/docs/spec/schema-guide.md
@@ -125,12 +125,13 @@ A template variable definition with type information and validation rules.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | **Yes** | Variable name used in templates (e.g., `{{name}}`). Pattern: `^[a-zA-Z_][a-zA-Z0-9_]*$`. |
-| `type` | string | **Yes** | Data type. One of: `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`. |
+| `type` | string | **Yes** | Data type. Schema is open — common values are `"string"`, `"number"`, `"boolean"`, `"object"`, `"array"`. |
 | `required` | boolean | **Yes** | Whether this variable must be provided at runtime. |
-| `default` | any | No | Default value when the variable is not provided. |
+| `default` | any | No | Default value when the variable is not provided. Should not be set when `required: true`. |
 | `description` | string | No | Human-readable description of the variable's purpose. |
 | `example` | any | No | Example value showing expected format and content. |
 | `validation` | [Validation](#validation) | No | Validation rules applied to the variable value at runtime. |
+| `binding` | [Binding](#binding) | No | Declares how this variable is automatically populated from runtime context (e.g., session, env, request header) without caller input. |
 
 ### Validation
 
@@ -144,6 +145,30 @@ Rules applied to variable values at runtime.
 | `minimum` | number | Minimum numeric value (for number types). |
 | `maximum` | number | Maximum numeric value (for number types). |
 | `enum` | any[] | List of allowed values. |
+
+### Binding
+
+Declares how a variable is auto-populated from runtime context, so the caller doesn't have to supply it explicitly.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kind` | string | No | The binding source kind. Schema is open — common values are `"context"`, `"session"`, `"env"`, `"header"`. |
+| `field` | string | No | The field name within the binding source to extract (e.g., `"user_id"`, `"locale"`). |
+| `auto_populate` | boolean | No | Whether this variable is automatically populated at runtime without caller input. Default: `false`. |
+| `filter` | string | No | Optional filter expression applied to the bound value (e.g., `"lowercase"`, `"trim"`). |
+
+```json
+{
+  "name": "user_id",
+  "type": "string",
+  "required": true,
+  "binding": {
+    "kind": "session",
+    "field": "user_id",
+    "auto_populate": true
+  }
+}
+```
 
 ```json
 {
@@ -247,8 +272,9 @@ A validation rule (guardrail) applied to LLM responses.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | string | **Yes** | The validator type that determines how validation is performed. Not an enum — runtimes define and register their own types. Examples: `"banned_words"`, `"max_length"`, `"length"`, `"max_sentences"`, `"regex_match"`, `"sentiment"`, `"custom"`. |
-| `enabled` | boolean | **Yes** | Whether this validator is active. |
-| `fail_on_violation` | boolean | No | If true, violations cause an error. Default: false. |
+| `enabled` | boolean | No | Whether this validator is active. Default: `true`. |
+| `fail_on_violation` | boolean | No | If true, violations cause an error. If false, violations are logged but allowed. Default: `false`. |
+| `message` | string | No | User-facing message returned when the validator blocks content (e.g., `"Response contains banned words"`). |
 | `params` | object | No | Validator-specific parameters (e.g., word lists, character limits). |
 
 ```json
@@ -363,13 +389,17 @@ Evals are automated quality checks on LLM outputs. Unlike validators (which run 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `id` | string | **Yes** | Unique identifier for this eval within its scope. |
-| `type` | string | **Yes** | Assertion type determining how the eval runs. Not an enum — runtimes register their own types (e.g., `"contains"`, `"regex"`, `"json_valid"`, `"llm_judge"`). |
-| `trigger` | string | **Yes** | When this eval fires. One of: `"every_turn"`, `"on_session_complete"`, `"sample_turns"`, `"sample_sessions"`. |
+| `type` | string | **Yes** | Assertion type determining how the eval runs. Not an enum — runtimes register their own types (e.g., `"contains"`, `"regex"`, `"json_valid"`, `"llm_judge"`, `"cosine_similarity"`). |
+| `trigger` | string | **Yes** | When this eval fires. Schema is open — common values are `"every_turn"`, `"on_session_complete"`, `"on_conversation_complete"`, `"on_workflow_step"`, `"sample_turns"`, `"sample_sessions"`. |
 | `description` | string | No | Human-readable description of what this eval measures. |
 | `enabled` | boolean | No | Whether this eval is active. Default: `true`. |
 | `sample_percentage` | number | No | Percentage of turns/sessions to sample (0–100). Only used with `sample_turns` and `sample_sessions` triggers. Default: `5`. |
 | `params` | object | No | Type-specific configuration. Structure depends on the eval `type`. |
 | `metric` | [MetricDef](#metric-def) | No | Prometheus-style metric declaration for exposing eval results. |
+| `threshold` | [Threshold](#threshold) | No | Pass/fail threshold for the eval score. |
+| `message` | string | No | Human-readable message describing the eval result or failure reason. |
+| `when` | object | No | Conditional expression that determines whether this eval runs for a given turn or session (e.g., `{ "has_variable": "customer_tier" }`, `{ "turn_count_gte": 3 }`). Free-form — runtimes interpret. |
+| `groups` | string[] | No | Eval group tags for organizing and filtering evals (e.g., `["quality", "tone"]`, `["safety", "compliance"]`). |
 
 ### Metric Def
 
@@ -380,6 +410,15 @@ Evals are automated quality checks on LLM outputs. Unlike validators (which run 
 | `range` | object | No | Optional value bounds with `min` and/or `max` fields. |
 
 The `metric` object uses `additionalProperties: true`, so runtimes can attach extra fields (e.g., `labels`, `help`, `buckets`).
+
+### Threshold
+
+Optional pass/fail threshold attached to an eval. Runtimes compare the eval's numeric score against `value` using `operator`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `operator` | string | Comparison operator. Common values: `"gte"`, `"lte"`, `"gt"`, `"lt"`, `"eq"`. |
+| `value` | number | The threshold value to compare against (e.g., `0.8`, `4`, `0.95`). |
 
 ```json
 "evals": [


### PR DESCRIPTION
## Summary

Follow-up audit to PR #42. Cross-checked every public doc against `schema/promptpack.schema.json` and fixed several mismatches that pre-date the v1.4 work.

## What changed

**`schema-guide.md`**
- `Variable.binding` — schema has a full `Binding` sub-object (`kind`, `field`, `auto_populate`, `filter`); was completely undocumented. Added the section.
- `Variable.type` — softened "One of:" wording (schema is open, not an enum).
- `Variable.default` — added schema constraint that it should not be set when `required: true`.
- `Validator.enabled` — was wrongly marked Required Yes; schema makes it optional with `default: true`.
- `Validator.message` — user-facing block-message string was undocumented.
- `Eval` — added four missing fields: `threshold` (with new Threshold sub-section for `operator`/`value`), `message`, `when`, `groups`.
- `Eval.trigger` — softened "One of:" wording and added `on_conversation_complete` and `on_workflow_step` from the schema.

**`setup-agents.md`**
- `AgentDef.description` — schema has zero required fields on `AgentDef`; doc was telling authors `description` is required in three places (step 2, validation checklist, common-mistakes). Reframed as "technically optional in the schema but strongly recommended for A2A discovery".
- Prereq bumped from "v1.3 schema" to "v1.3+ schema".

**`add-evals.md`**
- Triggers — schema is open, not an enum. Added `on_conversation_complete` and `on_workflow_step` to the triggers table; softened the validation-checklist language. Kept `metric.type` strict (it actually is an enum).

**`add-skills.md`**
- Prereq bumped from "v1.3.1 schema" to "v1.3.1+ schema" so v1.4 packs aren't told they're invalid.

No example pack changes — all worked examples were already valid against the current schema.

## Test plan

- [x] Built locally (`npm run build`) — 0 errors.
- [x] Each new field cross-checked directly against `schema/promptpack.schema.json`.
- [ ] Reviewer: spot-check the new Variable / Validator / Eval tables against the schema.