### PR TITLE
feat(docs): giscus comment box on RFC pages

### DIFF
--- a/promptpack-docs/docusaurus.config.ts
+++ b/promptpack-docs/docusaurus.config.ts
@@ -32,6 +32,20 @@ const config: Config = {
   onBrokenLinks: 'throw',
   onBrokenAnchors: 'warn',
 
+  // giscus comment widget config, consumed by src/theme/DocItem/Footer.
+  // Renders a comment box on individual RFC pages (/docs/rfcs/<slug>), backed
+  // by GitHub Discussions. The footer no-ops until repoId + categoryId are set.
+  // One-time setup: see promptpack-docs/src/theme/DocItem/Footer/SETUP-giscus.md
+  customFields: {
+    giscus: {
+      repo: 'altairalabs/promptpack-spec',
+      repoId: '', // TODO: from https://giscus.app
+      category: 'RFC Comments',
+      categoryId: '', // TODO: from https://giscus.app
+      mapping: 'pathname',
+    },
+  },
+
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".

--- a/promptpack-docs/docusaurus.config.ts
+++ b/promptpack-docs/docusaurus.config.ts
@@ -39,9 +39,9 @@ const config: Config = {
   customFields: {
     giscus: {
       repo: 'altairalabs/promptpack-spec',
-      repoId: '', // TODO: from https://giscus.app
+      repoId: 'R_kgDOQMvRhA',
       category: 'RFC Comments',
-      categoryId: '', // TODO: from https://giscus.app
+      categoryId: 'DIC_kwDOQMvRhM4C_FUh',
       mapping: 'pathname',
     },
   },

--- a/promptpack-docs/src/theme/DocItem/Footer/SETUP-giscus.md
+++ b/promptpack-docs/src/theme/DocItem/Footer/SETUP-giscus.md
@@ -1,0 +1,46 @@
+# giscus setup (one-time, maintainer)
+
+RFC pages on the docs site render a [giscus](https://giscus.app) comment box,
+backed by GitHub Discussions. The widget is wired up in
+`src/theme/DocItem/Footer/index.tsx` and configured via `customFields.giscus`
+in `docusaurus.config.ts`. It **no-ops until the two IDs below are filled in**,
+so the site builds and deploys safely before setup is complete.
+
+## Steps
+
+1. **Install the giscus GitHub App** on the `altairalabs/promptpack-spec` repo:
+   https://github.com/apps/giscus (grant it access to this repo only).
+   The repo must be public and have Discussions enabled (it does).
+
+2. **Create a Discussions category** named **`RFC Comments`**
+   (repo → Settings → Discussions, or the Discussions tab → "New category").
+   A free-form "Open" format is fine; giscus creates one discussion per RFC page
+   on first comment.
+
+3. **Generate the IDs** at https://giscus.app:
+   - Repository: `altairalabs/promptpack-spec`
+   - Page ↔ Discussions mapping: **pathname**
+   - Category: **RFC Comments**
+   - Copy the emitted `data-repo-id` and `data-category-id`.
+
+4. **Fill them into `docusaurus.config.ts`** → `customFields.giscus`:
+   ```ts
+   repoId: 'R_xxxx…',
+   categoryId: 'DIC_xxxx…',
+   ```
+
+5. Commit. The comment box now appears at the bottom of every RFC page.
+
+## Scope / behaviour
+
+- Renders only on individual RFC pages (`/docs/rfcs/<slug>`), not the index.
+- One GitHub Discussion per RFC page (`mapping: pathname`).
+- Light/dark theme follows the site's color mode.
+- Loaded client-side and lazily; zero npm dependency (script embed).
+
+## Changing scope
+
+To show comments on other docs, widen the `isRfcPage` test in
+`src/theme/DocItem/Footer/index.tsx`. To turn comments off entirely, blank the
+`repoId`/`categoryId` in `customFields.giscus` (the footer falls back to the
+stock footer).

--- a/promptpack-docs/src/theme/DocItem/Footer/index.tsx
+++ b/promptpack-docs/src/theme/DocItem/Footer/index.tsx
@@ -1,0 +1,87 @@
+import React, {useEffect, useRef} from 'react';
+import OriginalFooter from '@theme-original/DocItem/Footer';
+import type FooterType from '@theme/DocItem/Footer';
+import type {WrapperProps} from '@docusaurus/types';
+import {useLocation} from '@docusaurus/router';
+import {useColorMode} from '@docusaurus/theme-common';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+type Props = WrapperProps<typeof FooterType>;
+
+type GiscusConfig = {
+  repo?: string;
+  repoId?: string;
+  category?: string;
+  categoryId?: string;
+  mapping?: string;
+};
+
+const GISCUS_THEME = (mode: string) => (mode === 'dark' ? 'dark' : 'light');
+
+/**
+ * Injects the giscus comment widget (https://giscus.app) via its client script.
+ * Script embed is used instead of @giscus/react so the docs site gains no npm
+ * dependency (keeps `npm ci` / the lockfile untouched). Backed by GitHub
+ * Discussions; one discussion per page (mapping: pathname).
+ */
+function GiscusComments({cfg, mode}: {cfg: GiscusConfig; mode: string}): React.ReactElement {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Inject the giscus script once per mount.
+  useEffect(() => {
+    const container = ref.current;
+    if (!container || container.querySelector('script')) {
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute('data-repo', cfg.repo ?? '');
+    script.setAttribute('data-repo-id', cfg.repoId ?? '');
+    script.setAttribute('data-category', cfg.category ?? '');
+    script.setAttribute('data-category-id', cfg.categoryId ?? '');
+    script.setAttribute('data-mapping', cfg.mapping ?? 'pathname');
+    script.setAttribute('data-strict', '1');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-theme', GISCUS_THEME(mode));
+    script.setAttribute('data-lang', 'en');
+    script.setAttribute('data-loading', 'lazy');
+    container.appendChild(script);
+  }, [cfg]);
+
+  // Re-theme the existing iframe on light/dark toggle without a reload.
+  useEffect(() => {
+    const iframe = document.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+    iframe?.contentWindow?.postMessage(
+      {giscus: {setConfig: {theme: GISCUS_THEME(mode)}}},
+      'https://giscus.app',
+    );
+  }, [mode]);
+
+  return <div ref={ref} className="giscus" style={{marginTop: '3rem'}} />;
+}
+
+export default function FooterWrapper(props: Props): React.ReactElement {
+  const {pathname} = useLocation();
+  const {colorMode} = useColorMode();
+  const {siteConfig} = useDocusaurusContext();
+  const cfg = (siteConfig.customFields?.giscus ?? {}) as GiscusConfig;
+
+  // Only on individual RFC pages (/docs/rfcs/<slug>), never the index.
+  const isRfcPage = /\/docs\/rfcs\/.+/.test(pathname);
+  // No-op until the giscus IDs are configured (see SETUP-giscus.md).
+  const isConfigured = Boolean(cfg.repoId && cfg.categoryId);
+
+  return (
+    <>
+      <OriginalFooter {...props} />
+      {isRfcPage && isConfigured && (
+        <BrowserOnly>{() => <GiscusComments cfg={cfg} mode={colorMode} />}</BrowserOnly>
+      )}
+    </>
+  );
+}

--- a/promptpack-docs/src/theme/DocItem/Footer/index.tsx
+++ b/promptpack-docs/src/theme/DocItem/Footer/index.tsx
@@ -43,10 +43,10 @@ function GiscusComments({cfg, mode}: {cfg: GiscusConfig; mode: string}): React.R
     script.setAttribute('data-category', cfg.category ?? '');
     script.setAttribute('data-category-id', cfg.categoryId ?? '');
     script.setAttribute('data-mapping', cfg.mapping ?? 'pathname');
-    script.setAttribute('data-strict', '1');
+    script.setAttribute('data-strict', '0');
     script.setAttribute('data-reactions-enabled', '1');
     script.setAttribute('data-emit-metadata', '0');
-    script.setAttribute('data-input-position', 'top');
+    script.setAttribute('data-input-position', 'bottom');
     script.setAttribute('data-theme', GISCUS_THEME(mode));
     script.setAttribute('data-lang', 'en');
     script.setAttribute('data-loading', 'lazy');


### PR DESCRIPTION
## Summary

Makes it easy to comment on an RFC: every individual RFC page on promptpack.org (`/docs/rfcs/<slug>`) gets an inline **giscus** comment box at the bottom, backed by GitHub Discussions (one thread per RFC). No more hunting for the PR — and unlike PRs, Discussions stay open for RFCs that remain Draft/Implemented and keep drawing feedback.

## How

- Swizzles `DocItem/Footer` (`promptpack-docs/src/theme/DocItem/Footer/index.tsx`) to render the original footer + giscus on RFC pages only.
- Uses the **giscus script embed**, not `@giscus/react` — so there's **no new npm dependency** and `package-lock.json` / `npm ci` are untouched.
- **Guarded:** the widget no-ops until `repoId`/`categoryId` are filled into `customFields.giscus` in `docusaurus.config.ts`, so the site builds and deploys safely *before* the GitHub-side setup is done.
- Comment theme follows the site's light/dark color mode.

## Required one-time setup (maintainer — can't be automated)

Documented in `promptpack-docs/src/theme/DocItem/Footer/SETUP-giscus.md`:
1. Install the giscus GitHub App on this repo.
2. Create a Discussions category **"RFC Comments"**.
3. Generate `repo-id` + `category-id` at https://giscus.app (mapping: pathname).
4. Paste them into `customFields.giscus`.

Until then the box simply doesn't render.

## Verification

- `npm run typecheck` — clean.
- `npm run build` — succeeds (SSR through the swizzled footer, `onBrokenLinks: throw`); all RFC pages render.
