### PR TITLE
docs(rfc-0010): clarify reducer `into` reference form

### DIFF
--- a/rfcs/0010-workflow-composition.md
+++ b/rfcs/0010-workflow-composition.md
@@ -406,7 +406,7 @@ Reducers name how a parallel block's branch outputs are merged into a single val
       },
       "into": {
         "type": "string",
-        "description": "Name under which the merged result is exposed to subsequent steps."
+        "description": "Field name under which the merged result is placed on the parallel step's output. Subsequent steps reference it as ${<parallelStepId>.output.<into>} — e.g. a 'barrier' reduce with 'into: metadata' on parallel step 'extract_metadata' is read as ${extract_metadata.output.metadata}, consistent with the ${stepId.output.X} reference model used everywhere else."
       }
     },
     "required": ["strategy", "into"]


### PR DESCRIPTION
## Problem

RFC 0010 (Workflow Composition) is internally inconsistent about how a `parallel` step's reduced result is referenced downstream.

- The **`Reducer.into`** description says: *"Name under which the merged result is exposed to subsequent steps"* — which reads as a top-level variable (i.e. `${into.X}`, e.g. `${metadata}`).
- But **Example 3 (`deep_analyze`)** accesses it as:
  ```yaml
  reduce: { strategy: barrier, into: metadata }
  ...
  input: "${extract_metadata.output.metadata}"
  ```
  i.e. `${<parallelStepId>.output.<into>}`.

These two forms contradict each other.

## Fix

Clarify the `into` description to match the example **and** the `${stepId.output.X}` reference model used everywhere else in the RFC (StepInput, predicate paths). `into` names a field placed on the parallel step's output; downstream steps read it as `${<parallelStepId>.output.<into>}`. The example is already in this form, so only the description changes (1 line).

This keeps every value in a composition under the two existing namespaces (`${input.X}` and `${stepId.output.X}`) rather than introducing a third top-level reducer namespace that could collide with step ids.

## Alternative considered

The other direction — change Example 3 to `${metadata...}` and define `into` as a top-level variable — was rejected because it breaks the uniform two-namespace scope model and risks collisions with step ids.

_Surfaced while auditing the RFC during the PromptKit implementation design (AltairaLabs/PromptKit epic #1337)._
